### PR TITLE
Fix minor issues in Makefile for Release 0.1 (#33)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,23 @@
 CC = gcc
 CXX = g++
-#Checks the compiler version and associate corresponding flag
-# eg : for [version > 11] _zicsr flag is required
-GCC_VERSION := $(shell riscv64-unknown-elf-gcc --version | head -n 1 | awk '{print $$3}')
-GCC_MAJOR := $(word 1, $(subst ., ,$(GCC_VERSION)))
-GCC_MINOR := $(word 2, $(subst ., ,$(GCC_VERSION)))
+
+# Function to normalize version strings into a numeric format for easier comparison
+# Converts version like 11.0.0 to 110000
+define normalize_version
+  $(shell echo $(1) | awk -F. '{ printf "%d%02d%02d", $$1, $$2, $$3 }')  
+endef
+
+GCC_MIN_VERSION := 11.0.0
+GCC_VERSION := $(shell riscv64-unknown-elf-gcc --version | head -n 1 | sed 's/.* //')  # For example: 9.3.0
+
+MIN_VERSION_NUMERIC := $(call normalize_version, $(GCC_MIN_VERSION)) # Converts 11.0.0 -> 110000
+CURRENT_VERSION_NUMERIC := $(call normalize_version, $(GCC_VERSION))  # Converts 9.3.0 -> 90300
+
+# Compare normalized versions and issue a warning if the current version is lower than the minimum required version
+#I dont know about you guys but my gcc version is 9.3.0 and i cant seem to go higher so I will get a warning
+ifeq ($(shell [ $(CURRENT_VERSION_NUMERIC) -lt $(MIN_VERSION_NUMERIC) ] && echo 1 || echo 0), 1)
+  $(warning Bad toolchain version $(GCC_VERSION). Minimum required: $(GCC_MIN_VERSION))
+endif
 
 TARGET_EXEC := slash_sim
 
@@ -28,7 +41,8 @@ INC_FLAGS := $(addprefix -I,$(INC_DIRS))
 # Compilation flags
 CPPFLAGS := $(INC_FLAGS) -MMD -MP
 
-ifeq ($(shell test $(GCC_MAJOR) -ge 11 && echo 1), 1)
+# Set MARCH_FLAG based on normalized GCC version comparison if gcc version > min version then use rv32i_zicsr else use rv32i
+ifeq ($(shell [ $(CURRENT_VERSION_NUMERIC) -lt $(MIN_VERSION_NUMERIC) ] && echo 1 || echo 0), 0)
     MARCH_FLAG := -march=rv32i_zicsr
 else
     MARCH_FLAG := -march=rv32i
@@ -39,7 +53,6 @@ ARGS ?=
 LD_FILE ?= rv32.ld
 
 # Default target
-.PHONY: all
 all: $(BUILD_DIR)/$(TARGET_EXEC)
 
 # Link final executable
@@ -57,26 +70,22 @@ $(BUILD_DIR)/%.cpp.o: %.cpp
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $< -o $@
 
 # Run target
-.PHONY: run
 run: all
 	@mkdir -p $(OUT_DIR)/$(ASM)
 	./$(BUILD_DIR)/$(TARGET_EXEC) $(ARGS) $(ASM)
 
 # Debug target
-.PHONY: debug
 debug: all
 	@mkdir -p $(OUT_DIR)/$(ASM)
 	gdb --args ./$(BUILD_DIR)/$(TARGET_EXEC) $(ARGS) $(ASM)
 
 # Assembly build target
-.PHONY: asm
 asm:
 	@mkdir -p ./$(BUILD_DIR)
 	riscv64-unknown-elf-gcc $(MARCH_FLAG) -mabi=ilp32 -static -nostdlib -T$(ASMDIR)/$(LD_FILE) $(ASMDIR)/$(ASM).s -o $(BUILD_DIR)/${ASM}.elf
 	riscv64-unknown-elf-objcopy -O binary $(BUILD_DIR)/$(ASM).elf $(BUILD_DIR)/$(ASM).bin
 
 # Clean up build files
-.PHONY: clean
 clean:
 	@rm -rf $(BUILD_DIR) $(OUT_DIR)
 


### PR DESCRIPTION
This PR addresses minor issues in the Makefile for Release 0.1, as mentioned in issue #33. 
This PR includes fixes for concerns raised in the issue except 2nd one:
1) Removed GCC major minor variables
3) Added min version for newer flags
4) Removed all Phony variables.
